### PR TITLE
fix(treesitter): fix markdown injection crash on nvim 0.12

### DIFF
--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -34,6 +34,17 @@ vim.filetype.add({
 	},
 })
 
+-- nvim-treesitter is incompatible with nvim 0.12's captures API for markdown
+-- injections (TSNode[] vs TSNode mismatch in set-lang-from-info-string!),
+-- causing crashes in both the highlighter and vim-matchup. Stop treesitter
+-- for markdown until upstream fixes the predicate handler.
+vim.api.nvim_create_autocmd("FileType", {
+	pattern = "markdown",
+	callback = function()
+		vim.treesitter.stop()
+	end,
+})
+
 -- Disable automatic line breaks
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "*",

--- a/lua/plugins/configs/matchup.lua
+++ b/lua/plugins/configs/matchup.lua
@@ -2,5 +2,7 @@ return {
   "andymass/vim-matchup",
   config = function()
     vim.g.matchup_matchparen_offscreen = { method = "popup" }
+    -- disable matchup's treesitter engine for markdown (same nvim 0.12 incompatibility)
+    vim.g.matchup_treesitter_disabled = { "markdown" }
   end,
 }

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -117,9 +117,6 @@ return {
 				-- enables vim-matchup integration
 				enable = true,
 				enable_quotes = true,
-				-- markdown injections (bash/sh code blocks) trigger a nil-node crash
-				-- in the treesitter injection layer; fall back to regex matching there
-				disable = { "markdown" },
 			},
 			-- incremental_selection = {
 			--     enable = true,

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -117,6 +117,9 @@ return {
 				-- enables vim-matchup integration
 				enable = true,
 				enable_quotes = true,
+				-- markdown injections (bash/sh code blocks) trigger a nil-node crash
+				-- in the treesitter injection layer; fall back to regex matching there
+				disable = { "markdown" },
 			},
 			-- incremental_selection = {
 			--     enable = true,


### PR DESCRIPTION
## Summary

- nvim 0.12 changed `_apply_directives` to pass `TSNode[]` per capture instead of a single `TSNode`; nvim-treesitter's `set-lang-from-info-string!` predicate calls `node:range()` on the array and crashes
- This broke both the treesitter highlighter and vim-matchup whenever a markdown file was opened
- Stop treesitter entirely for markdown via a `FileType` autocmd until nvim-treesitter ships a fix for the predicate handler
- Disable matchup's treesitter engine for markdown via `vim.g.matchup_treesitter_disabled` as a belt-and-suspenders guard

## Test plan

- [x] Open a `.md` file with fenced code blocks — no E5108 error on open or cursor move
- [x] Enter insert mode in the markdown file — no E5108 error on `InsertEnter`
- [x] Verify matchup (`%`) still works in markdown via the regex engine fallback
- [x] Confirm treesitter still works normally in non-markdown files (e.g. Lua, YAML)
- [x] When nvim-treesitter fixes the `set-lang-from-info-string!` predicate: remove the autocmd and `matchup_treesitter_disabled` line to re-enable