### PR TITLE
feat(ci): validate neovim with all plugins via lazy.nvim sync

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,9 +38,36 @@ jobs:
       - name: Check Neovim version
         run: docker run --rm nvim-config:ci nvim --version
 
-      - name: Validate Neovim starts headless
+      - name: Prepare plugin data directory
+        run: |
+          mkdir -p $HOME/.local/share/nvim-ci
+          chmod 777 $HOME/.local/share/nvim-ci
+
+      - name: Cache lazy.nvim plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/nvim-ci
+          key: nvim-plugins-${{ hashFiles('lua/plugins/**/*.lua') }}
+          restore-keys: nvim-plugins-
+
+      - name: Install plugins via lazy.nvim
         run: |
           docker run --rm \
+            -e CI=true \
             -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
+            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
             nvim-config:ci \
-            nvim --headless --noplugin +qall
+            nvim --headless \
+              -c "lua require('lazy').sync({wait=true, show=false})" \
+              -c "qall"
+        timeout-minutes: 15
+
+      - name: Validate Neovim loads with all plugins
+        run: |
+          docker run --rm \
+            -e CI=true \
+            -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
+            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
+            nvim-config:ci \
+            nvim --headless -c "qall"
+        timeout-minutes: 2

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ package-lock.json
 # Built Visual Studio Code Extensions
 *.vsix
 .vscode/settings.json
+devcontainer-lock.json

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -3,14 +3,14 @@ return {
 		"mason-org/mason.nvim",
 		config = function()
 			require("mason").setup({
-        ui = {
-          icons = {
-            package_installed = "✓",
-            package_pending = "➜",
-            package_uninstalled = "✗",
-          }
-        }
-      })
+				ui = {
+					icons = {
+						package_installed = "✓",
+						package_pending = "➜",
+						package_uninstalled = "✗",
+					},
+				},
+			})
 		end,
 	},
 	{
@@ -18,27 +18,28 @@ return {
 		config = function()
 			require("mason-lspconfig").setup({
 				automatic_enable = false,
-				ensure_installed = {
-          "ansiblels",
-          "awk_ls",
-          "bashls",
-          "clangd",
+				-- skip heavy binary downloads in CI; lazy.nvim plugin code is still validated
+				ensure_installed = vim.env.CI and {} or {
+					"ansiblels",
+					"awk_ls",
+					"bashls",
+					"clangd",
 					"docker_compose_language_service",
 					"dockerls",
 					"dotls",
-          "elixirls",
+					"elixirls",
 					"eslint",
-          "gradle_ls",
-          "groovyls",
+					"gradle_ls",
+					"groovyls",
 					"html",
-          "jdtls",
-          "jqls",
-          "jsonls",
-          "kotlin_language_server",
+					"jdtls",
+					"jqls",
+					"jsonls",
+					"kotlin_language_server",
 					"lua_ls",
-          "matlab_ls",
-          "perlnavigator",
-          "pyright",
+					"matlab_ls",
+					"perlnavigator",
+					"pyright",
 					"rust_analyzer",
 					"tsp_server",
 					"yamlls",
@@ -46,56 +47,42 @@ return {
 			})
 		end,
 	},
-  {
-    "williamboman/mason.nvim",
-    "mfussenegger/nvim-lint",
-    "rshkarin/mason-nvim-lint",
-    config = function()
-      require('mason-nvim-lint').setup({
-        -- Whether linters that are set up (via nvim-lint) should be automatically installed if they're not already installed.
-        -- It tries to find the specified linters in the mason's registry to proceed with installation.
-        -- This setting has no relation with the `ensure_installed` setting.
-        ---@type boolean
-        automatic_installation = true,
-
-        -- Disables warning notifications about misconfigurations such as invalid linter entries and incorrect plugin load order.
-        quiet_mode = false,        
-
-        -- A list of linters to automatically install if they're not already installed. Example: { "eslint_d", "revive" }
-        -- This setting has no relation with the `automatic_installation` setting.
-        -- Names of linters should be taken from the mason's registry.
-        ---@type string[]
-        ensure_installed = {
-          "actionlint",
-          "ansible-lint",
-          "api-linter",
-          "black",
-          "cmakelang",
-          "csharpier",
-          "cpplint",
-          "dotenv-linter",
-          "elm-formatter",
-          "eslint_d",
-          "jq",
-          "kube-linter",
-          "luacheck",
-          "markdownlint",
-          "markdown-toc",
-          "prettier",
-          "pylint",
-          "xmlformatter",
-          "yamlfix",
-          "yamlfmt",
-          "yamllint",
-          "zsh",
-        },        
-
-        -- Avoid trying to install an unknown linter
-        ignore_install = {},
-
-      })
-    end,
-  },
+	{
+		"williamboman/mason.nvim",
+		"mfussenegger/nvim-lint",
+		"rshkarin/mason-nvim-lint",
+		config = function()
+			require("mason-nvim-lint").setup({
+				automatic_installation = not vim.env.CI,
+				quiet_mode = false,
+				ensure_installed = vim.env.CI and {} or {
+					"actionlint",
+					"ansible-lint",
+					"api-linter",
+					"black",
+					"cmakelang",
+					"csharpier",
+					"cpplint",
+					"dotenv-linter",
+					"elm-formatter",
+					"eslint_d",
+					"jq",
+					"kube-linter",
+					"luacheck",
+					"markdownlint",
+					"markdown-toc",
+					"prettier",
+					"pylint",
+					"xmlformatter",
+					"yamlfix",
+					"yamlfmt",
+					"yamllint",
+					"zsh",
+				},
+				ignore_install = {},
+			})
+		end,
+	},
 	{
 		"williamboman/mason-nvim-dap.nvim",
 		dependencies = {
@@ -105,7 +92,7 @@ return {
 		},
 		config = function()
 			require("mason-nvim-dap").setup({
-				ensure_installed = {
+				ensure_installed = vim.env.CI and {} or {
 					"codelldb",
 					"javatest",
 					"javadbg",


### PR DESCRIPTION
Install all lazy.nvim plugins headlessly in CI using lazy.sync({wait=true}). Skip Mason binary downloads (LSP servers, linters, DAP adapters) via vim.env.CI guard to keep CI fast. Cache plugin data keyed on plugin config file hashes. Ignore devcontainer-lock.json.