### PR TITLE
feat: SRE tooling, Kubernetes YAML validation, and Claude Code integration

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,7 +79,9 @@ jobs:
             -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
             -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
             nvim-config:ci \
-            nvim --headless -c "TSUpdateSync" -c "qall"
+            nvim --headless \
+              -c "luafile /home/dev/.config/nvim/test/install_parsers.lua" \
+              -c "qall"
         timeout-minutes: 10
 
       - name: Test Go and Terraform treesitter parsers

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,3 +71,25 @@ jobs:
             nvim-config:ci \
             nvim --headless -c "qall"
         timeout-minutes: 2
+
+      - name: Install treesitter parsers (Go, Terraform, HCL)
+        run: |
+          docker run --rm \
+            -e CI=true \
+            -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
+            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
+            nvim-config:ci \
+            nvim --headless -c "TSUpdateSync" -c "qall"
+        timeout-minutes: 10
+
+      - name: Test Go and Terraform treesitter parsers
+        run: |
+          docker run --rm \
+            -e CI=true \
+            -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
+            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
+            nvim-config:ci \
+            nvim --headless \
+              -c "luafile /home/dev/.config/nvim/test/validate_treesitter.lua" \
+              -c "qall"
+        timeout-minutes: 2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,60 +38,12 @@ jobs:
       - name: Check Neovim version
         run: docker run --rm nvim-config:ci nvim --version
 
-      - name: Prepare plugin data directory
-        run: |
-          mkdir -p $HOME/.local/share/nvim-ci
-          chmod 777 $HOME/.local/share/nvim-ci
-
-      - name: Cache lazy.nvim plugins
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/nvim-ci
-          key: nvim-plugins-${{ hashFiles('lua/plugins/**/*.lua') }}
-          restore-keys: nvim-plugins-
-
-      - name: Install plugins via lazy.nvim
+      - name: Run all Neovim validations
         run: |
           docker run --rm \
+            --network=host \
             -e CI=true \
             -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
-            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
             nvim-config:ci \
-            nvim --headless \
-              -c "lua require('lazy').sync({wait=true, show=false})" \
-              -c "qall"
-        timeout-minutes: 15
-
-      - name: Validate Neovim loads with all plugins
-        run: |
-          docker run --rm \
-            -e CI=true \
-            -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
-            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
-            nvim-config:ci \
-            nvim --headless -c "qall"
-        timeout-minutes: 2
-
-      - name: Install treesitter parsers (Go, Terraform, HCL)
-        run: |
-          docker run --rm \
-            -e CI=true \
-            -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
-            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
-            nvim-config:ci \
-            nvim --headless \
-              -c "luafile /home/dev/.config/nvim/test/install_parsers.lua" \
-              -c "qall"
-        timeout-minutes: 10
-
-      - name: Test Go and Terraform treesitter parsers
-        run: |
-          docker run --rm \
-            -e CI=true \
-            -v "${{ github.workspace }}:/home/dev/.config/nvim:ro" \
-            -v "$HOME/.local/share/nvim-ci:/home/dev/.local/share/nvim" \
-            nvim-config:ci \
-            nvim --headless \
-              -c "luafile /home/dev/.config/nvim/test/validate_treesitter.lua" \
-              -c "qall"
-        timeout-minutes: 2
+            bash /home/dev/.config/nvim/test/ci_validate.sh
+        timeout-minutes: 30

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -45,6 +45,14 @@ vim.api.nvim_create_autocmd("FileType", {
 	end,
 })
 
+-- Disable cmp autocompletion for YAML — we want linting/diagnostics only
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "yaml",
+  callback = function()
+    require("cmp").setup.buffer({ enabled = false })
+  end,
+})
+
 -- Disable automatic line breaks
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "*",

--- a/lua/lsp/configs/go.lua
+++ b/lua/lsp/configs/go.lua
@@ -1,0 +1,33 @@
+return {
+	"leoluz/nvim-dap-go",
+	ft = "go",
+	dependencies = {
+		"mfussenegger/nvim-dap",
+	},
+	config = function()
+		require("dap-go").setup({
+			dap_configurations = {
+				{
+					type = "go",
+					name = "Attach remote",
+					mode = "remote",
+					request = "attach",
+				},
+			},
+			delve = {
+				path = "dlv",
+				initialize_timeout_sec = 20,
+				port = "${port}",
+				args = {},
+				build_flags = "",
+				detached = vim.fn.has("win32") == 0,
+			},
+		})
+
+		local wk = require("which-key")
+		wk.add({
+			{ "<leader>dt", "<cmd>lua require('dap-go').debug_test()<cr>", desc = "[GO] Debug test under cursor" },
+			{ "<leader>dT", "<cmd>lua require('dap-go').debug_last_test()<cr>", desc = "[GO] Debug last test" },
+		})
+	end,
+}

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -140,8 +140,18 @@ if lspconfig then
 
   -- Go Language Server
   lspconfig("gopls", {
-    autostart = false,
+    autostart = true,
     capabilities = capabilities,
+    settings = {
+      gopls = {
+        analyses = {
+          unusedparams = true,
+          shadow = true,
+        },
+        staticcheck = true,
+        gofumpt = true,
+      },
+    },
   })
 
   -- Gradle Language Server

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -114,10 +114,32 @@ if lspconfig then
 		capabilities = capabilities,
 	})
 
-	-- YAMLs
+	-- YAMLs — diagnostics only, no completion
   lspconfig("yamlls", {
+    autostart = true,
     capabilities = capabilities,
-  	autostart = false,
+    settings = {
+      yaml = {
+        validate = true,
+        hover = true,
+        completion = false,
+        schemaStore = {
+          enable = true,
+          url = "https://www.schemastore.org/api/json/catalog.json",
+        },
+        schemas = {
+          -- Kubernetes manifests in common SRE directory layouts
+          kubernetes = {
+            "manifests/**/*.yaml",
+            "k8s/**/*.yaml",
+            "kubernetes/**/*.yaml",
+            "deploy/**/*.yaml",
+            "templates/**/*.yaml",
+            "chart/templates/**/*.yaml",
+          },
+        },
+      },
+    },
   })
 
   -- CMake Language Server

--- a/lua/plugins/configs/claudecode.lua
+++ b/lua/plugins/configs/claudecode.lua
@@ -1,0 +1,60 @@
+return {
+  -- Claude Code integration via the same WebSocket/MCP protocol as the VS Code extension.
+  -- Opens claude CLI in a native terminal split; tracks your active buffer and selection
+  -- so Claude has context without you having to paste anything.
+  {
+    "coder/claudecode.nvim",
+    cmd = {
+      "ClaudeCode",
+      "ClaudeCodeFocus",
+      "ClaudeCodeSend",
+      "ClaudeCodeAdd",
+      "ClaudeCodeTreeAdd",
+      "ClaudeCodeDiffAccept",
+      "ClaudeCodeDiffDeny",
+      "ClaudeCodeSelectModel",
+      "ClaudeCodeStatus",
+    },
+    keys = {
+      { "<leader>ac", "<cmd>ClaudeCode<cr>",            desc = "[AI] Toggle Claude Code" },
+      { "<leader>af", "<cmd>ClaudeCodeFocus<cr>",       desc = "[AI] Focus Claude Code" },
+      { "<leader>as", "<cmd>ClaudeCodeSend<cr>",        mode = "v", desc = "[AI] Send selection" },
+      { "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>",       desc = "[AI] Add buffer to context" },
+      { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>",  desc = "[AI] Accept diff" },
+      { "<leader>aD", "<cmd>ClaudeCodeDiffDeny<cr>",    desc = "[AI] Deny diff" },
+      { "<leader>am", "<cmd>ClaudeCodeSelectModel<cr>", desc = "[AI] Select model" },
+      -- Add file to Claude context from file explorers
+      { "<leader>as", "<cmd>ClaudeCodeTreeAdd<cr>",
+        ft = { "neo-tree", "NvimTree", "oil", "netrw" },
+        desc = "[AI] Add file to context" },
+    },
+    opts = {
+      terminal = {
+        provider = "native",
+        split_side = "right",
+        split_width_percentage = 0.38,
+        auto_close = true,
+        auto_insert = true,
+      },
+      track_selection = true,
+      diff_opts = {
+        layout = "vertical",
+        auto_resize_terminal = true,
+      },
+    },
+    config = function(_, opts)
+      require("claudecode").setup(opts)
+      require("which-key").add({
+        { "<leader>a", group = "AI / Claude Code" },
+      })
+    end,
+  },
+
+  -- LSP completions inside Claude Code's Ctrl+G compose buffers:
+  -- slash commands (/compact, /clear …), @file references, and installed skills.
+  {
+    "kezhenxu94/nvim-claude-lsp",
+    ft = { "markdown", "text" },
+    opts = {},
+  },
+}

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -20,6 +20,8 @@ return {
 				automatic_enable = false,
 				-- skip heavy binary downloads in CI; lazy.nvim plugin code is still validated
 				ensure_installed = vim.env.CI and {} or {
+					"gopls",
+					"terraform-ls",
 					"ansiblels",
 					"awk_ls",
 					"bashls",
@@ -56,6 +58,7 @@ return {
 				automatic_installation = not vim.env.CI,
 				quiet_mode = false,
 				ensure_installed = vim.env.CI and {} or {
+					"tflint",
 					"actionlint",
 					"ansible-lint",
 					"api-linter",
@@ -93,6 +96,7 @@ return {
 		config = function()
 			require("mason-nvim-dap").setup({
 				ensure_installed = vim.env.CI and {} or {
+					"delve",
 					"codelldb",
 					"javatest",
 					"javadbg",

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -84,6 +84,18 @@ return {
 				},
 				ignore_install = {},
 			})
+
+			-- Wire up nvim-lint: which linters run per filetype and when
+			local lint = require("lint")
+			lint.linters_by_ft = {
+				yaml = { "yamllint" },
+			}
+			vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter" }, {
+				pattern = { "*.yaml", "*.yml" },
+				callback = function()
+					lint.try_lint()
+				end,
+			})
 		end,
 	},
 	{

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -36,7 +36,11 @@ return {
 				"javascript",
 				"typescript",
 				"vue",
-        "toml"
+				"toml",
+				-- SRE
+				"go",
+				"terraform",
+				"hcl",
 			},
 			refactor = {
 				highlight_definitions = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -86,6 +86,7 @@ local plugins = {
 	require("plugins.configs.mason"),
 	"neovim/nvim-lspconfig",
   require("lsp.configs.dap"),
+	require("lsp.configs.go"),
 	require("lsp.configs.java"),
 	require("lsp.configs.rust"),
 	require("lsp.configs.python"),

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -116,6 +116,9 @@ local plugins = {
 
   -- Latex based on VimTex
   require("plugins.configs.latex"),
+
+  ---- AI
+  require("plugins.configs.claudecode"),
 }
 
 -- vim.api.nvim_echo({ { 'Active theme: ' .. theme.theme_name, "Normal" } }, true, {});

--- a/test/ci_install_plugins.lua
+++ b/test/ci_install_plugins.lua
@@ -1,0 +1,11 @@
+-- Headless lazy.nvim plugin installer for CI.
+-- Exits 1 loudly if lazy.nvim is not loadable or sync fails.
+local ok, lazy = pcall(require, 'lazy')
+if not ok then
+  io.stderr:write('FATAL: lazy.nvim not loadable: ' .. tostring(lazy) .. '\n')
+  vim.cmd('cquit 1')
+end
+
+print('lazy.nvim loaded, starting sync...')
+lazy.sync({ wait = true, show = false })
+print('lazy.nvim sync complete')

--- a/test/ci_validate.sh
+++ b/test/ci_validate.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+echo "=== Bootstrapping lazy.nvim ==="
+git clone --filter=blob:none \
+  https://github.com/folke/lazy.nvim.git \
+  --branch=stable \
+  "$HOME/.local/share/nvim/lazy/lazy.nvim"
+
+echo "=== Installing plugins via lazy.nvim ==="
+nvim --headless \
+  -c "luafile /home/dev/.config/nvim/test/ci_install_plugins.lua" \
+  -c "qall"
+
+echo "=== Validating Neovim startup with all plugins ==="
+nvim --headless -c "qall"
+
+echo "=== Installing treesitter parsers (Go, Terraform, HCL) ==="
+nvim --headless \
+  -c "luafile /home/dev/.config/nvim/test/install_parsers.lua" \
+  -c "qall"
+
+echo "=== Testing Go and Terraform treesitter parsers ==="
+nvim --headless \
+  -c "luafile /home/dev/.config/nvim/test/validate_treesitter.lua" \
+  -c "qall"
+
+echo "=== All validations passed! ==="

--- a/test/fixtures/deployment.yaml
+++ b/test/fixtures/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-app
+  namespace: default
+  labels:
+    app: hello-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-app
+  template:
+    metadata:
+      labels:
+        app: hello-app
+    spec:
+      containers:
+        - name: hello-app
+          image: nginx:1.25
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"

--- a/test/fixtures/hello.go
+++ b/test/fixtures/hello.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func greet(name string) string {
+	return fmt.Sprintf("Hello, %s!", name)
+}
+
+func main() {
+	name := os.Getenv("USER")
+	if name == "" {
+		name = "SRE"
+	}
+	fmt.Println(greet(name))
+}

--- a/test/fixtures/main.tf
+++ b/test/fixtures/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "dev"
+}
+
+locals {
+  greeting = "Hello from environment: ${var.environment}"
+}
+
+resource "local_file" "hello" {
+  content  = local.greeting
+  filename = "${path.module}/hello.txt"
+}
+
+output "message" {
+  value = local.greeting
+}

--- a/test/install_parsers.lua
+++ b/test/install_parsers.lua
@@ -1,7 +1,7 @@
 -- Headless treesitter parser installer for CI.
 -- Uses TSInstall! + vim.wait() polling parser .so files on disk.
 -- Exit code 1 on timeout so the CI step fails visibly.
-local langs = { 'go', 'terraform', 'hcl' }
+local langs = { 'go', 'terraform', 'hcl', 'yaml' }
 local parser_dir = vim.fn.stdpath('data') .. '/lazy/nvim-treesitter/parser/'
 
 local function installed(lang)

--- a/test/install_parsers.lua
+++ b/test/install_parsers.lua
@@ -1,0 +1,38 @@
+-- Headless treesitter parser installer for CI.
+-- Uses TSInstall! + vim.wait() polling parser .so files on disk.
+-- Exit code 1 on timeout so the CI step fails visibly.
+local langs = { 'go', 'terraform', 'hcl' }
+local parser_dir = vim.fn.stdpath('data') .. '/lazy/nvim-treesitter/parser/'
+
+local function installed(lang)
+  return vim.fn.filereadable(parser_dir .. lang .. '.so') == 1
+end
+
+for _, lang in ipairs(langs) do
+  if installed(lang) then
+    print('SKIP [' .. lang .. ']: already compiled')
+  else
+    print('INST [' .. lang .. ']: installing...')
+    pcall(vim.cmd, 'TSInstall! ' .. lang)
+  end
+end
+
+local ok = vim.wait(300000, function()
+  for _, lang in ipairs(langs) do
+    if not installed(lang) then return false end
+  end
+  return true
+end, 2000)
+
+if not ok then
+  for _, lang in ipairs(langs) do
+    if not installed(lang) then
+      io.stderr:write('FAIL [' .. lang .. ']: compile timed out\n')
+    end
+  end
+  vim.cmd('cquit 1')
+else
+  for _, lang in ipairs(langs) do
+    print('OK   [' .. lang .. ']: parser ready')
+  end
+end

--- a/test/validate_treesitter.lua
+++ b/test/validate_treesitter.lua
@@ -1,0 +1,48 @@
+-- Headless treesitter validation script.
+-- Exit code 1 on any failure so CI catches it.
+local errors = {}
+
+local function test_parser(lang, filepath)
+  local lines = vim.fn.readfile(filepath)
+  if #lines == 0 then
+    table.insert(errors, string.format('[%s] fixture not found or empty: %s', lang, filepath))
+    return
+  end
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+  local ok, result = pcall(vim.treesitter.get_parser, buf, lang)
+  if not ok then
+    table.insert(errors, string.format('[%s] parser load failed: %s', lang, tostring(result)))
+    vim.api.nvim_buf_delete(buf, { force = true })
+    return
+  end
+
+  local ok2, trees = pcall(function() return result:parse() end)
+  if not ok2 then
+    table.insert(errors, string.format('[%s] parse failed: %s', lang, tostring(trees)))
+    vim.api.nvim_buf_delete(buf, { force = true })
+    return
+  end
+
+  if not trees or #trees == 0 then
+    table.insert(errors, string.format('[%s] no parse trees returned', lang))
+    vim.api.nvim_buf_delete(buf, { force = true })
+    return
+  end
+
+  vim.api.nvim_buf_delete(buf, { force = true })
+  print(string.format('OK   [%s]: treesitter parser works', lang))
+end
+
+local cfg = '/home/dev/.config/nvim'
+test_parser('go',        cfg .. '/test/fixtures/hello.go')
+test_parser('terraform', cfg .. '/test/fixtures/main.tf')
+
+if #errors > 0 then
+  for _, err in ipairs(errors) do
+    io.stderr:write('FAIL ' .. err .. '\n')
+  end
+  vim.cmd('cquit 1')
+end

--- a/test/validate_treesitter.lua
+++ b/test/validate_treesitter.lua
@@ -39,6 +39,7 @@ end
 local cfg = '/home/dev/.config/nvim'
 test_parser('go',        cfg .. '/test/fixtures/hello.go')
 test_parser('terraform', cfg .. '/test/fixtures/main.tf')
+test_parser('yaml',      cfg .. '/test/fixtures/deployment.yaml')
 
 if #errors > 0 then
   for _, err in ipairs(errors) do

--- a/test/validate_treesitter.lua
+++ b/test/validate_treesitter.lua
@@ -13,7 +13,7 @@ local function test_parser(lang, filepath)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
 
   local ok, result = pcall(vim.treesitter.get_parser, buf, lang)
-  if not ok then
+  if not ok or result == nil then
     table.insert(errors, string.format('[%s] parser load failed: %s', lang, tostring(result)))
     vim.api.nvim_buf_delete(buf, { force = true })
     return


### PR DESCRIPTION
## Summary

- **Go & Terraform LSP**: gopls, terraformls, tflint wired up with treesitter parsers; CI validates parsers compile correctly
- **CI overhaul**: fixed headless lazy.nvim install and DinD bind-mount issue by collapsing all validation steps into a single `docker run` via `test/ci_validate.sh`
- **Kubernetes YAML**: yamlls with schema validation (`validate=true`, `completion=false`, schemaStore auto-detect); yamllint via nvim-lint triggered on save; cmp disabled for yaml buffers
- **Claude Code** (`coder/claudecode.nvim`): native terminal split (right, 38%), `<leader>a*` keymaps, which-key group; `kezhenxu94/nvim-claude-lsp` for slash-command/`@file` completions in Claude compose buffers

## Test plan

- [x] `act push` CI passes (lazy sync, treesitter parser compilation for go/terraform/hcl/yaml, startup validation)
- [x] Open a `.go` file → gopls attaches, hover works
- [x] Open a `.tf` file → terraformls attaches
- [x] Open a Kubernetes YAML → yamlls shows schema errors inline; yamllint triggers on save; no completion popup
- [x] `<leader>ac` → Claude Code terminal opens in right split
- [x] `<leader>as` (visual) → selection sent to Claude
- [x] `<leader>ab` → current buffer added to Claude context