### PR TITLE
feat(sre): add Helm, Bash and Dockerfile LSP, linting and formatting

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -189,10 +189,33 @@ if lspconfig then
 	})
 
   -- Helm Language Server
-  --[[ lspconfig("helm_ls", {
-    autostart = false,
+  lspconfig("helm_ls", {
+    autostart = true,
     capabilities = capabilities,
-  }) --]]
+    settings = {
+      ['helm-ls'] = {
+        logLevel = "info",
+        valuesFiles = {
+          mainValuesFile = "values.yaml",
+          lintOverlayValuesFile = "values.lint.yaml",
+          additionalValuesFilesGlobPattern = "values*.yaml",
+        },
+        yamlls = {
+          enabled = true,
+          diagnosticsLimit = 50,
+          showDiagnosticsDirectly = false,
+          path = "yaml-language-server",
+          config = {
+            schemas = {
+              kubernetes = "templates/**",
+            },
+            completion = true,
+            hover = true,
+          },
+        },
+      },
+    },
+  })
   
   -- Json Language Server
   lspconfig("jsonls", {

--- a/lua/plugins/configs/conform.lua
+++ b/lua/plugins/configs/conform.lua
@@ -24,7 +24,7 @@ return {
 
 		formatters_by_ft = {
 			lua = { "stylua" },
-			sh = { "beautysh" },
+			sh = { "shfmt" },
 			json = { "jq" },
 			html = { "prettierd", "prettier", "tidy", stop_after_first = true },
 			css = { "prettierd", "prettier", "tidy", stop_after_first = true },

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -22,6 +22,7 @@ return {
 				ensure_installed = vim.env.CI and {} or {
 					"gopls",
 					"terraform-ls",
+					"helm_ls",
 					"ansiblels",
 					"awk_ls",
 					"bashls",
@@ -59,6 +60,9 @@ return {
 				quiet_mode = false,
 				ensure_installed = vim.env.CI and {} or {
 					"tflint",
+					"shellcheck",
+					"shfmt",
+					"hadolint",
 					"actionlint",
 					"ansible-lint",
 					"api-linter",
@@ -88,10 +92,13 @@ return {
 			-- Wire up nvim-lint: which linters run per filetype and when
 			local lint = require("lint")
 			lint.linters_by_ft = {
-				yaml = { "yamllint" },
+				yaml       = { "yamllint" },
+				sh         = { "shellcheck" },
+				bash       = { "shellcheck" },
+				dockerfile = { "hadolint" },
 			}
 			vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter" }, {
-				pattern = { "*.yaml", "*.yml" },
+				pattern = { "*.yaml", "*.yml", "*.sh", "Dockerfile", "dockerfile" },
 				callback = function()
 					lint.try_lint()
 				end,

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -41,6 +41,8 @@ return {
 				"go",
 				"terraform",
 				"hcl",
+				"bash",
+				"gotmpl",
 			},
 			refactor = {
 				highlight_definitions = {

--- a/test/fixtures/Dockerfile
+++ b/test/fixtures/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:12-slim AS base
+
+ARG APP_VERSION=1.0.0
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+FROM base AS builder
+
+COPY . .
+
+RUN chmod +x ./entrypoint.sh
+
+FROM base AS runtime
+
+COPY --from=builder /app/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENV APP_VERSION=${APP_VERSION}
+
+EXPOSE 8080
+
+USER nobody
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/test/fixtures/helm_deployment.yaml
+++ b/test/fixtures/helm_deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mychart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mychart.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${1:-default}"
+
+echo "Checking pods in namespace: ${NAMESPACE}"
+
+pods=$(kubectl get pods -n "${NAMESPACE}" --no-headers 2>/dev/null | wc -l)
+
+if [[ "${pods}" -eq 0 ]]; then
+  echo "No pods found in ${NAMESPACE}"
+  exit 1
+fi
+
+echo "Found ${pods} pod(s)"
+
+for pod in $(kubectl get pods -n "${NAMESPACE}" -o jsonpath='{.items[*].metadata.name}'); do
+  status=$(kubectl get pod "${pod}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
+  echo "  ${pod}: ${status}"
+done

--- a/test/install_parsers.lua
+++ b/test/install_parsers.lua
@@ -1,7 +1,7 @@
 -- Headless treesitter parser installer for CI.
 -- Uses TSInstall! + vim.wait() polling parser .so files on disk.
 -- Exit code 1 on timeout so the CI step fails visibly.
-local langs = { 'go', 'terraform', 'hcl', 'yaml' }
+local langs = { 'go', 'terraform', 'hcl', 'yaml', 'bash', 'gotmpl', 'dockerfile' }
 local parser_dir = vim.fn.stdpath('data') .. '/lazy/nvim-treesitter/parser/'
 
 local function installed(lang)

--- a/test/validate_treesitter.lua
+++ b/test/validate_treesitter.lua
@@ -37,9 +37,12 @@ local function test_parser(lang, filepath)
 end
 
 local cfg = '/home/dev/.config/nvim'
-test_parser('go',        cfg .. '/test/fixtures/hello.go')
-test_parser('terraform', cfg .. '/test/fixtures/main.tf')
-test_parser('yaml',      cfg .. '/test/fixtures/deployment.yaml')
+test_parser('go',         cfg .. '/test/fixtures/hello.go')
+test_parser('terraform',  cfg .. '/test/fixtures/main.tf')
+test_parser('yaml',       cfg .. '/test/fixtures/deployment.yaml')
+test_parser('bash',       cfg .. '/test/fixtures/script.sh')
+test_parser('gotmpl',     cfg .. '/test/fixtures/helm_deployment.yaml')
+test_parser('dockerfile', cfg .. '/test/fixtures/Dockerfile')
 
 if #errors > 0 then
   for _, err in ipairs(errors) do


### PR DESCRIPTION
## Summary

- **helm_ls**: enabled with internal yamlls integration for Helm template files; `values*.yaml` glob, kubernetes schema applied to `templates/**`
- **Bash**: `shellcheck` via nvim-lint on save; `shfmt` replaces `beautysh` as shell formatter in conform
- **Dockerfile**: `hadolint` via nvim-lint on save
- **Treesitter**: `bash` and `gotmpl` parsers added
- **CI**: parser install and validation extended to cover `bash`, `gotmpl`, `dockerfile`; fixtures `script.sh`, `Dockerfile`, `helm_deployment.yaml` added

## Test plan

- [ ] CI passes (bash/gotmpl/dockerfile parser compilation + treesitter fixture validation)
- [ ] Open a Helm chart template → helm_ls attaches, `{{ }}` expressions resolved
- [ ] Open a `.sh` file → bashls attaches; shellcheck diagnostics appear on save
- [ ] Format a `.sh` file → shfmt runs
- [ ] Open a `Dockerfile` → dockerls attaches; hadolint diagnostics appear on save