### PR TITLE
feat(sre): add Ansible, Jsonnet and Python support

### DIFF
--- a/after/lsp/ansiblels.lua
+++ b/after/lsp/ansiblels.lua
@@ -1,0 +1,22 @@
+vim.lsp.config('ansiblels', {
+  settings = {
+    ansible = {
+      ansible = {
+        path = "ansible",
+      },
+      executionEnvironment = {
+        enabled = false,
+      },
+      python = {
+        interpreterPath = "python3",
+      },
+      validation = {
+        enabled = true,
+        lint = {
+          enabled = true,
+          path = "ansible-lint",
+        },
+      },
+    },
+  },
+})

--- a/after/lsp/jsonnet_ls.lua
+++ b/after/lsp/jsonnet_ls.lua
@@ -1,0 +1,14 @@
+vim.lsp.config('jsonnet_ls', {
+  cmd = { "jsonnet-language-server", "-t" },
+  settings = {
+    ext_vars = {},
+    formatting = {
+      Indent = 2,
+      MaxBlankLines = 2,
+      StringStyle = "s",
+      CommentStyle = "s",
+      PrettyFieldNames = true,
+      SortImports = true,
+    },
+  },
+})

--- a/lua/plugins/configs/conform.lua
+++ b/lua/plugins/configs/conform.lua
@@ -25,6 +25,7 @@ return {
 		formatters_by_ft = {
 			lua = { "stylua" },
 			sh = { "shfmt" },
+		python = { "ruff_format" },
 			json = { "jq" },
 			html = { "prettierd", "prettier", "tidy", stop_after_first = true },
 			css = { "prettierd", "prettier", "tidy", stop_after_first = true },

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -28,6 +28,7 @@ return {
 					"terraformls",
 					"helm_ls",
 					"ansiblels",
+					"jsonnet_ls",
 					"bashls",
 					"dockerls",
 					"docker_compose_language_service",
@@ -60,6 +61,7 @@ return {
 					"shellcheck",
 					"shfmt",
 					"hadolint",
+					"ruff",
 					"actionlint",
 					"ansible-lint",
 					"api-linter",
@@ -93,9 +95,10 @@ return {
 				sh         = { "shellcheck" },
 				bash       = { "shellcheck" },
 				dockerfile = { "hadolint" },
+				python     = { "ruff" },
 			}
 			vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter" }, {
-				pattern = { "*.yaml", "*.yml", "*.sh", "Dockerfile", "dockerfile" },
+				pattern = { "*.yaml", "*.yml", "*.sh", "Dockerfile", "dockerfile", "*.py" },
 				callback = function()
 					lint.try_lint()
 				end,

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -43,6 +43,7 @@ return {
 				"hcl",
 				"bash",
 				"gotmpl",
+				"jsonnet",
 			},
 			refactor = {
 				highlight_definitions = {

--- a/test/ci_validate_lsp.lua
+++ b/test/ci_validate_lsp.lua
@@ -13,7 +13,7 @@ if not global_cfg or not global_cfg.capabilities then
 end
 
 -- Spot-check that server-specific after/lsp overrides are present
-local servers_with_settings = { "gopls", "lua_ls", "rust_analyzer", "yamlls", "helm_ls", "eslint" }
+local servers_with_settings = { "gopls", "lua_ls", "rust_analyzer", "yamlls", "helm_ls", "eslint", "ansiblels", "jsonnet_ls" }
 for _, name in ipairs(servers_with_settings) do
   local cfg = vim.lsp.config[name]
   if not cfg or not cfg.settings then

--- a/test/fixtures/dashboard.jsonnet
+++ b/test/fixtures/dashboard.jsonnet
@@ -1,0 +1,29 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local prometheus = grafana.target.prometheus;
+local graphPanel = grafana.graphPanel;
+
+dashboard.new(
+  'SRE Overview',
+  schemaVersion=26,
+  tags=['sre', 'platform'],
+  timezone='browser',
+  refresh='1m',
+)
+.addRow(
+  row.new(title='HTTP Traffic')
+  .addPanel(
+    graphPanel.new(
+      'Request Rate',
+      datasource='Prometheus',
+      span=6,
+    )
+    .addTarget(
+      prometheus.target(
+        'sum(rate(http_requests_total[5m])) by (status_code)',
+        legendFormat='{{status_code}}',
+      )
+    )
+  )
+)

--- a/test/fixtures/script.py
+++ b/test/fixtures/script.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Check pod health across a Kubernetes namespace."""
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class Pod:
+    name: str
+    namespace: str
+    status: str
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == "Running"
+
+
+def get_pods(namespace: str) -> list[Pod]:
+    result = subprocess.run(
+        ["kubectl", "get", "pods", "-n", namespace, "--no-headers",
+         "-o", "custom-columns=NAME:.metadata.name,STATUS:.status.phase"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pods = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            pods.append(Pod(name=parts[0], namespace=namespace, status=parts[1]))
+    return pods
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("namespace", default="default", nargs="?")
+    args = parser.parse_args()
+
+    pods = get_pods(args.namespace)
+    if not pods:
+        print(f"No pods found in {args.namespace}", file=sys.stderr)
+        return 1
+
+    failed = [p for p in pods if not p.healthy]
+    for pod in pods:
+        status = "OK" if pod.healthy else "FAIL"
+        print(f"  [{status}] {pod.name}: {pod.status}")
+
+    return len(failed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/install_parsers.lua
+++ b/test/install_parsers.lua
@@ -1,7 +1,7 @@
 -- Headless treesitter parser installer for CI.
 -- Uses TSInstall! + vim.wait() polling parser .so files on disk.
 -- Exit code 1 on timeout so the CI step fails visibly.
-local langs = { 'go', 'terraform', 'hcl', 'yaml', 'bash', 'gotmpl', 'dockerfile' }
+local langs = { 'go', 'terraform', 'hcl', 'yaml', 'bash', 'gotmpl', 'dockerfile', 'jsonnet', 'python' }
 local parser_dir = vim.fn.stdpath('data') .. '/lazy/nvim-treesitter/parser/'
 
 local function installed(lang)

--- a/test/validate_treesitter.lua
+++ b/test/validate_treesitter.lua
@@ -43,6 +43,8 @@ test_parser('yaml',       cfg .. '/test/fixtures/deployment.yaml')
 test_parser('bash',       cfg .. '/test/fixtures/script.sh')
 test_parser('gotmpl',     cfg .. '/test/fixtures/helm_deployment.yaml')
 test_parser('dockerfile', cfg .. '/test/fixtures/Dockerfile')
+test_parser('jsonnet',    cfg .. '/test/fixtures/dashboard.jsonnet')
+test_parser('python',     cfg .. '/test/fixtures/script.py')
 
 if #errors > 0 then
   for _, err in ipairs(errors) do


### PR DESCRIPTION
## Summary

- `after/lsp/ansiblels.lua`: Ansible LSP with validation and ansible-lint integration
- `after/lsp/jsonnet_ls.lua`: Jsonnet LSP with formatting settings and `-t` flag for Grafonnet/Tanka
- `mason.lua`: `jsonnet_ls` added to lspconfig servers; `ruff` added to nvim-lint; Python linting wired (`linters_by_ft`, autocmd pattern)
- `conform.lua`: `python = { "ruff_format" }` formatter
- `treesitter.lua`: `jsonnet` parser added to SRE section

## Test plan

- [ ] `jsonnet` and `python` parsers install and parse fixtures without errors
- [ ] `ansiblels` settings verified in `ci_validate_lsp.lua` spot-check
- [ ] `jsonnet_ls` settings verified in `ci_validate_lsp.lua` spot-check
- [ ] CI validate pipeline passes end-to-end