### PR TITLE
feat(lua-markdown): add lazydev.nvim and marksman

### DIFF
--- a/after/lsp/lua_ls.lua
+++ b/after/lsp/lua_ls.lua
@@ -3,7 +3,7 @@ vim.lsp.config('lua_ls', {
     Lua = {
       runtime = { version = "LuaJIT" },
       diagnostics = { globals = { "vim" } },
-      workspace = { library = vim.api.nvim_get_runtime_file("", true) },
+      -- workspace.library is managed by lazydev.nvim
       telemetry = { enable = false },
     },
   },

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -113,6 +113,7 @@ return {
 			}),
 			sources = {
 	--			{ name = "copilot" },
+				{ name = "lazydev", group_index = 0 },
 				{ name = "nvim_lsp" },
 				{ name = "nvim_lua" },
 				{ name = "luasnip" },

--- a/lua/plugins/configs/lazydev.lua
+++ b/lua/plugins/configs/lazydev.lua
@@ -1,0 +1,9 @@
+return {
+	"folke/lazydev.nvim",
+	ft = "lua",
+	opts = {
+		library = {
+			{ path = "${3rd}/luv/library", words = { "vim%.uv" } },
+		},
+	},
+}

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -35,6 +35,7 @@ return {
 					"yamlls",
 					-- General dev
 					"lua_ls",
+					"marksman",
 					"pyright",
 					"rust_analyzer",
 					"clangd",

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -44,6 +44,9 @@ return {
 				"bash",
 				"gotmpl",
 				"jsonnet",
+				-- Markdown
+				"markdown",
+				"markdown_inline",
 			},
 			refactor = {
 				highlight_definitions = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -83,6 +83,7 @@ local plugins = {
   require("plugins.configs.glance"),
 
 	---- LSP/DAP
+	require("plugins.configs.lazydev"),
 	require("plugins.configs.mason"),
 	"neovim/nvim-lspconfig",
   require("lsp.configs.dap"),

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,17 @@
+# Fixture: Markdown
+
+This file is used as a treesitter fixture for the `markdown` and `markdown_inline` parsers in CI validation.
+
+## Section
+
+A paragraph with **bold**, _italic_, and `inline code`.
+
+- List item one
+- List item two with a [link](https://example.com)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+```
+
+> Blockquote text here.

--- a/test/install_parsers.lua
+++ b/test/install_parsers.lua
@@ -1,7 +1,7 @@
 -- Headless treesitter parser installer for CI.
 -- Uses TSInstall! + vim.wait() polling parser .so files on disk.
 -- Exit code 1 on timeout so the CI step fails visibly.
-local langs = { 'go', 'terraform', 'hcl', 'yaml', 'bash', 'gotmpl', 'dockerfile', 'jsonnet', 'python' }
+local langs = { 'go', 'terraform', 'hcl', 'yaml', 'bash', 'gotmpl', 'dockerfile', 'jsonnet', 'python', 'markdown', 'markdown_inline' }
 local parser_dir = vim.fn.stdpath('data') .. '/lazy/nvim-treesitter/parser/'
 
 local function installed(lang)

--- a/test/validate_treesitter.lua
+++ b/test/validate_treesitter.lua
@@ -43,8 +43,10 @@ test_parser('yaml',       cfg .. '/test/fixtures/deployment.yaml')
 test_parser('bash',       cfg .. '/test/fixtures/script.sh')
 test_parser('gotmpl',     cfg .. '/test/fixtures/helm_deployment.yaml')
 test_parser('dockerfile', cfg .. '/test/fixtures/Dockerfile')
-test_parser('jsonnet',    cfg .. '/test/fixtures/dashboard.jsonnet')
-test_parser('python',     cfg .. '/test/fixtures/script.py')
+test_parser('jsonnet',          cfg .. '/test/fixtures/dashboard.jsonnet')
+test_parser('python',           cfg .. '/test/fixtures/script.py')
+test_parser('markdown',         cfg .. '/test/fixtures/README.md')
+test_parser('markdown_inline',  cfg .. '/test/fixtures/README.md')
 
 if #errors > 0 then
   for _, err in ipairs(errors) do


### PR DESCRIPTION
## Summary

- `lua/plugins/configs/lazydev.lua`: new plugin — lazydev.nvim provides accurate Neovim API completions for `lua_ls` (replaces manual `workspace.library`)
- `after/lsp/lua_ls.lua`: drop manual `workspace.library`; lazydev owns Neovim runtime path discovery
- `lua/plugins/configs/cmp.lua`: add `lazydev` source (group_index 0) so completions appear first in Lua files
- `mason.lua`: add `marksman` (Markdown LSP) to lspconfig ensure_installed; auto-enabled by `automatic_enable`
- `treesitter.lua`: add `markdown` and `markdown_inline` parsers
- `test/fixtures/README.md`: markdown fixture for treesitter CI validation
- CI: `markdown` and `markdown_inline` parsers installed and validated

## Test plan

- [ ] `markdown` parser loads and parses `README.md` fixture without errors
- [ ] `markdown_inline` parser loads and parses `README.md` fixture without errors
- [ ] lazydev plugin config loads without errors (validated via lazy.nvim sync in CI)
- [ ] CI validate pipeline passes end-to-end