### PR TITLE
refactor(rust): replace rust-tools.nvim with rustaceanvim

### DIFF
--- a/lua/lsp/configs/rust.lua
+++ b/lua/lsp/configs/rust.lua
@@ -1,169 +1,43 @@
 return {
-	-- Rust-tools
+	-- rustaceanvim: native LSP API Rust support (replaces archived rust-tools.nvim)
 	{
-		"simrat39/rust-tools.nvim",
-		dependencies = {
-			"neovim/nvim-lspconfig",
-			"nvim-lua/plenary.nvim",
-			"mfussenegger/nvim-dap",
-		},
-		enabled = true,
-		ft = { "rust", "toml" },
-		config = function()
-			local handlers = require("lsp.handlers")
-			local extension_path = require("mason-registry").get_package("codelldb"):get_install_path() .. "/extension/"
-			local codelldb_path = extension_path .. "adapter/codelldb"
-			local liblldb_path = extension_path .. "lldb/lib/liblldb.so"
-			local rust_tools = require("rust-tools")
-
-			rust_tools.setup({
+		"mrcjkb/rustaceanvim",
+		version = "^5",
+		lazy = false,
+		init = function()
+			vim.g.rustaceanvim = {
 				tools = {
-					executor = require("rust-tools.executors").termopen,
-					autoSetHints = true,
-					runnables = {
-						use_telescope = true,
-					},
-					reload_workspace_from_cargo_toml = true,
-					on_initialized = function()
-						vim.cmd([[
-                  augroup RustLSP
-                    autocmd CursorHold                      *.rs silent! lua vim.lsp.buf.document_highlight()
-                    autocmd CursorMoved,InsertEnter         *.rs silent! lua vim.lsp.buf.clear_references()
-                    autocmd BufEnter,CursorHold,InsertLeave *.rs silent! lua vim.lsp.codelens.refresh()
-                  augroup END
-                ]])
-					end,
-					inlay_hints = {
-						auto = false,
-						only_current_line = false,
-						show_parameter_hints = true,
-						parameter_hints_prefix = "<- ",
-						other_hints_prefix = "=> ",
-						max_len_align = false,
-						max_len_align_padding = 1,
-						right_align = false,
-						right_align_padding = 7,
-						highlight = "Comment",
-					},
-					hover_actions = {
-						border = {
-							{ "╭", "FloatBorder" },
-							{ "─", "FloatBorder" },
-							{ "╮", "FloatBorder" },
-							{ "│", "FloatBorder" },
-							{ "╯", "FloatBorder" },
-							{ "─", "FloatBorder" },
-							{ "╰", "FloatBorder" },
-							{ "│", "FloatBorder" },
-						},
-						max_width = nil,
-						max_height = nil,
-						auto_focus = true,
-					},
-					crate_graph = {
-						backend = "x11",
-						output = nil,
-						full = true,
-						enabled_graphviz_backends = {
-							"bmp",
-							"cgimage",
-							"canon",
-							"dot",
-							"gv",
-							"xdot",
-							"xdot1.2",
-							"xdot1.4",
-							"eps",
-							"exr",
-							"fig",
-							"gd",
-							"gd2",
-							"gif",
-							"gtk",
-							"ico",
-							"cmap",
-							"ismap",
-							"imap",
-							"cmapx",
-							"imap_np",
-							"cmapx_np",
-							"jpg",
-							"jpeg",
-							"jpe",
-							"jp2",
-							"json",
-							"json0",
-							"dot_json",
-							"xdot_json",
-							"pdf",
-							"pic",
-							"pct",
-							"pict",
-							"plain",
-							"plain-ext",
-							"png",
-							"pov",
-							"ps",
-							"ps2",
-							"psd",
-							"sgi",
-							"svg",
-							"svgz",
-							"tga",
-							"tiff",
-							"tif",
-							"tk",
-							"vml",
-							"vmlz",
-							"wbmp",
-							"webp",
-							"xlib",
-							"x11",
-						},
-					},
+					hover_actions = { auto_focus = true },
 				},
-				server = {
-					on_attach = function(_, bufnr)
-						handlers.on_attach(_, bufnr)
-						wk = require("which-key")
-						wk.add({
-							{ "<leader>dE", "<cmd>RustDebuggables<cr>", desc = "[RUST] Show debug configurations" },
-							{ "<leader>de", "<cmd>RustLastDebug<cr>", desc = "[RUST] Debug last" },
-							{ "<leader>dR", "<cmd>RustRun<cr>", desc = "[RUST] Show run configurations" },
-							{ "<leader>dr", "<cmd>RustLastRun<cr>", desc = "[RUST] Run last" },
+			}
+			-- Rust-specific keymaps; global on_attach is wired in lsp/init.lua via LspAttach
+			vim.api.nvim_create_autocmd("LspAttach", {
+				callback = function(args)
+					local client = vim.lsp.get_client_by_id(args.data.client_id)
+					if client and client.name == "rust_analyzer" then
+						require("which-key").add({
+							{ "<leader>dE", "<cmd>RustLsp debuggables<cr>",  desc = "[RUST] Show debuggables", buffer = args.buf },
+							{ "<leader>de", "<cmd>RustLsp! debuggables<cr>", desc = "[RUST] Debug last",       buffer = args.buf },
+							{ "<leader>dR", "<cmd>RustLsp runnables<cr>",    desc = "[RUST] Show runnables",   buffer = args.buf },
+							{ "<leader>dr", "<cmd>RustLsp! runnables<cr>",   desc = "[RUST] Run last",         buffer = args.buf },
 						})
-					end,
-					capabilities = handlers.capabilities,
-					standalone = false,
-				},
-				dap = {
-					adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
-				},
+					end
+				end,
 			})
 		end,
 	},
-	-- Crates
+	-- crates.nvim: Cargo.toml dependency management
 	{
 		"saecki/crates.nvim",
 		enabled = true,
-    event = { "BufRead Cargo.toml" },
+		event = { "BufRead Cargo.toml" },
 		tag = "v0.4.0",
 		lazy = true,
 		dependencies = { "nvim-lua/plenary.nvim" },
 		config = function()
 			require("crates").setup({
-				src = {
-					--[[ 	coq = {
-						enabled = true,
-						name = "crates.nvim",
-					}, ]]
-					cmp = {
-						enabled = true,
-					},
-				},
-				popup = {
-					border = "rounded",
-				},
+				src = { cmp = { enabled = true } },
+				popup = { border = "rounded" },
 			})
 		end,
 	},

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -17,9 +17,9 @@ return {
 		"mason-org/mason-lspconfig.nvim",
 		config = function()
 			require("mason-lspconfig").setup({
-				-- Auto-enable all installed servers; jdtls has its own startup lifecycle
+				-- Auto-enable all installed servers; jdtls + rust_analyzer have their own lifecycle
 				automatic_enable = {
-					exclude = { "jdtls" },
+					exclude = { "jdtls", "rust_analyzer" },
 				},
 				-- skip heavy binary downloads in CI; lazy.nvim plugin code is still validated
 				ensure_installed = vim.env.CI and {} or {


### PR DESCRIPTION
## Summary

- `rust-tools.nvim` is archived (unmaintained) and internally calls `lspconfig.rust_analyzer.setup()`, conflicting with `mason-lspconfig` `automatic_enable` — rust_analyzer would start twice
- Replaced with `mrcjkb/rustaceanvim` v5, which uses the native Neovim LSP API (`vim.lsp.config` / `vim.lsp.enable`)
- Server settings remain in `after/lsp/rust_analyzer.lua` (rustaceanvim v5 reads `vim.lsp.config`)
- Rust keymaps wired via `LspAttach` autocmd — consistent with the global pattern in `lsp/init.lua`
- `rust_analyzer` added to `automatic_enable.exclude`; rustaceanvim owns the server lifecycle
- `crates.nvim` unchanged

## Test plan

- [ ] `after/lsp/rust_analyzer.lua` settings still verified by `ci_validate_lsp.lua` spot-check
- [ ] Plugin sync loads rustaceanvim without errors
- [ ] CI validate pipeline passes end-to-end