### PR TITLE
fix(lsp): remove deprecated vim.lsp.with() and unmaintained lsp-lens.nvim

### DIFF
--- a/lua/lsp/handlers.lua
+++ b/lua/lsp/handlers.lua
@@ -34,7 +34,9 @@ end
 local function set_hover_border(client)
 	local hp = client.server_capabilities.hoverProvider
 	if hp == true or (type(hp) == "table" and next(hp) ~= nil) then
-		vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, { border = border })
+		vim.lsp.handlers["textDocument/hover"] = function(err, result, ctx, config)
+			return vim.lsp.handlers.hover(err, result, ctx, vim.tbl_extend("force", config or {}, { border = border }))
+		end
 	end
 end
 

--- a/lua/plugins/configs/lens.lua
+++ b/lua/plugins/configs/lens.lua
@@ -1,6 +1,0 @@
-return {
-    "VidocqH/lsp-lens.nvim",
-    config = function()
-        require("lsp-lens").setup()
-    end,
-}

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -78,7 +78,6 @@ local plugins = {
 	---- Code
 	require("plugins.configs.lspsaga"),
 	require("plugins.configs.refactor"),
-	require("plugins.configs.lens"),
 	require("plugins.configs.conform"), -- Formatting tool
   require("plugins.configs.glance"),
 


### PR DESCRIPTION
## Summary

- Replace `vim.lsp.with()` in `lua/lsp/handlers.lua` with a direct handler wrapper — `vim.lsp.with()` was removed in Nvim 0.12
- Remove `VidocqH/lsp-lens.nvim`: unmaintained since Dec 2023; uses `client.supports_method` (dot notation) which will error in Nvim 0.13

## Remaining warnings (upstream)

The following warnings come from third-party plugins and cannot be fixed from this config:

| Plugin | Warning | Removed in |
|--------|---------|-----------|
| `bigfile.nvim`, `glance.nvim`, `hydra.nvim`, `mason-nvim-dap` | `vim.validate{<table>}` | Nvim 1.0 |

All four are already at their latest upstream commits with no fix available.