### PR TITLE
chore(ci): update pull_request target branch from master to main

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- Update `.github/workflows/validate.yml`: change `pull_request.branches` from `master` to `main` following the default branch rename.

Without this fix, PRs targeting `main` do not trigger CI.