### PR TITLE
feat(themes): modular plug-n-play colorscheme system

### DIFF
--- a/lua/plugins/configs/lualine.lua
+++ b/lua/plugins/configs/lualine.lua
@@ -5,7 +5,10 @@ return {
         require("lualine").setup({
             options = {
                 icons_enabled = true,
-                theme = require("theme").theme_name,
+                -- "auto" derives the statusline palette from whatever colorscheme
+                -- is active, so any theme in lua/themes/ works without a matching
+                -- lualine theme name.
+                theme = "auto",
                 disabled_filetypes = {},
                 always_divide_middle = true,
                 globalstatus = true,

--- a/lua/theme.lua
+++ b/lua/theme.lua
@@ -1,5 +1,17 @@
+-- Plug-n-play theme system.
+--
+-- Each colorscheme lives in its own file under lua/themes/<name>.lua and returns
+-- a lazy.nvim plugin spec. To add a theme: drop a new file in lua/themes/ — no
+-- edits here required. To switch: `:Theme <name>` (persists across restarts) or
+-- set the default in lua/settings.lua via set_active_theme(...).
+--
+-- Only the *active* theme plugin is installed (get_active_theme marks it
+-- lazy=false / priority=1000); the others are never fetched, keeping startup lean.
+
 local M = {}
 
+-- Fixed accent palette consumed by some plugin configs (bufferline, scrollbar).
+-- Independent of the active colorscheme.
 M.colors = {
 	bg = "#2e3440",
 	fg = "#ECEFF4",
@@ -33,177 +45,121 @@ M.colors = {
 	grey19 = "#020203",
 }
 
-local function loadNoClownFiesta()
-	vim.cmd([[colorscheme no-clown-fiesta]])
-	require("no-clown-fiesta").setup({
-		transparent = false, -- Enable this to disable the bg color
-		styles = {
-			-- You can set any of the style values specified for `:h nvim_set_hl`
-			comments = {},
-			keywords = {},
-			functions = {},
-			variables = {},
-			type = { bold = true },
-		},
-	})
+-- Machine-local persisted choice (not tracked in the repo).
+local state_file = vim.fn.stdpath("data") .. "/active-theme.txt"
+
+-- Discover available theme names from lua/themes/*.lua on the runtimepath.
+function M.list()
+	local seen, names = {}, {}
+	for _, path in ipairs(vim.api.nvim_get_runtime_file("lua/themes/*.lua", true)) do
+		local name = vim.fn.fnamemodify(path, ":t:r")
+		if not seen[name] then
+			seen[name] = true
+			names[#names + 1] = name
+		end
+	end
+	table.sort(names)
+	return names
 end
 
-local themes = {
-    onenord = {
-        "rmehri01/onenord.nvim",
-        config = function()
-            require('onenord').setup {
-                borders = true,
-                fade_nc = false,
-                styles = {
-                    comments = "italic",
-                    strings = "NONE",
-                    keywords = "NONE",
-                    functions = "italic",
-                    variables = "bold",
-                    diagnostics = "underline"
-                },
-                disable = {
-                    background = false,
-                    cursorline = false,
-                    eob_lines = true
-                },
-                colors = {},
-            }
-        end
-    },
-    tokyonight = {
-        "folke/tokyonight.nvim",
-        config = function()
-            local theme = require('tokyonight')
-            theme.setup({
-                style = 'night',
-                on_colors = function(colors)
-                    colors.bg_dark = '#000000'
-                    colors.bg = '#11121D'
-                    -- colors.bg_visual = M.colors.grey12
-                end
-            })
-            theme.load()
-        end
-    },
-    onedark = {
-        "navarasu/onedark.nvim",
-        config = function()
-            local theme = require('onedark')
-            theme.setup {
-                style = 'deep',
-                transparent = false, -- Show/hide background
-                code_style = {
-                    comments = 'italic',
-                    keywords = 'none',
-                    functions = 'none',
-                    strings = 'none',
-                    variables = 'none'
-                },
-                lualine = {
-                    transparent = true, -- lualine center bar transparency
-                },
-            }
-            theme.load()
-            -- loadNoClownFiesta()
-        end
-    },
-    palenightfall = {
-        "JoosepAlviste/palenightfall.nvim",
-        config = function()
-            require('palenightfall').setup {}
-        end
-    },
-    nordic = {
-        "AlexvZyl/nordic.nvim",
-        config = function()
-            require('nordic').setup {}
-        end
-    },
-    onedarkpro = {
-        "olimorris/onedarkpro.nvim",
-        config = function()
-            vim.o.background = "dark"
-            require('onedarkpro').load()
-        end
-    },
-    tokyodark = {
-        "tiagovla/tokyodark.nvim",
-        config = function()
-            vim.g.tokyodark_transparent_background = false
-            vim.g.tokyodark_enable_italic_comment = true
-            vim.g.tokyodark_enable_italic = true
-            vim.g.tokyodark_color_gamma = "0.0"
-            vim.cmd 'colorscheme tokyodark'
-        end
-    },
-    moonfly = {
-        "bluz71/vim-moonfly-colors",
-        config = function()
-            vim.cmd [[colorscheme moonfly]]
-        end
-    },
-    dracula = {
-        "Mofiqul/dracula.nvim",
-        config = function()
-            local theme = require('dracula')
-            theme.setup {}
-            theme.load()
-        end
-    },
-    draculanight = {
-        "magidc/draculanight",
-        config = function()
-            local theme = require('draculanight')
-            theme.setup {}
-            theme.load()
-        end
-    },
-    catppuccin = {
-        "catppuccin/nvim",
-        name = "catppuccin",
-        config = function()
-            vim.g.catppuccin_flavour = "mocha" -- latte, frappe, macchiato, mocha
-            vim.cmd [[colorscheme catppuccin]]
-        end
-    },
-    material = {
-        "marko-cerovac/material.nvim",
-        config = function()
-            require "plugins.configs.materialui"
-        end
-    },
-    gruvbox = {
-      'sainnhe/gruvbox-material',
-      lazy = false,
-      config = function()
-        -- Optionally configure and load the colorscheme
-        -- directly inside the plugin declaration.
-        vim.g.gruvbox_material_enable_italic = true
-        vim.cmd.colorscheme('gruvbox-material')
-        vim.g.show_eob = 1
-        vim.g.background = 'dark'
-        vim.g.gruvbox_material_background = 'hard'
-        vim.g.gruvbox_material_foreground = 'material'
-        vim.g.gruvbox_material_cursor = 'auto'
-        vim.g.gruvbox_material_show_eob = 0
-        vim.g.gruvbox_material_ui_contrast = 'high'
-        vim.g.gruvbox_material_float_style = 'bright' 
-        vim.g.gruvbox_material_transparent_background = 2
-      end        
-    },
-}
-
-M.set_active_theme = function(theme_name)
-	M.theme_name = theme_name
+local function is_valid(name)
+	for _, n in ipairs(M.list()) do
+		if n == name then
+			return true
+		end
+	end
+	return false
 end
 
-M.get_active_theme = function()
-	local theme = themes[M.theme_name]
-	theme.lazy = false
-	theme.priority = 1000
-	return theme
+local function read_persisted()
+	local f = io.open(state_file, "r")
+	if not f then
+		return nil
+	end
+	local name = vim.trim(f:read("*a") or "")
+	f:close()
+	return name ~= "" and name or nil
 end
+
+local function write_persisted(name)
+	local f = io.open(state_file, "w")
+	if not f then
+		return false
+	end
+	f:write(name)
+	f:close()
+	return true
+end
+
+-- Default theme, set from lua/settings.lua. A persisted `:Theme` choice wins.
+function M.set_active_theme(name)
+	M.default_theme = name
+	if not M.theme_name then
+		M.theme_name = name
+	end
+end
+
+local function resolve_name()
+	local persisted = read_persisted()
+	if persisted and is_valid(persisted) then
+		return persisted
+	end
+	if M.default_theme and is_valid(M.default_theme) then
+		return M.default_theme
+	end
+	return M.default_theme or M.list()[1]
+end
+
+-- Returns the lazy.nvim spec for the active theme (the only one that gets installed).
+function M.get_active_theme()
+	local name = resolve_name()
+	M.theme_name = name
+	local ok, spec = pcall(require, "themes." .. name)
+	if not ok or type(spec) ~= "table" then
+		vim.notify("theme: failed to load 'themes." .. tostring(name) .. "': " .. tostring(spec), vim.log.levels.ERROR)
+		return {}
+	end
+	spec.lazy = false
+	spec.priority = 1000
+	return spec
+end
+
+-- :Theme            -> show current + available
+-- :Theme <name>     -> persist choice (restart to apply; only active is installed)
+vim.api.nvim_create_user_command("Theme", function(opts)
+	local name = vim.trim(opts.args)
+	local themes = M.list()
+	if name == "" then
+		vim.notify(
+			"Active theme: " .. (M.theme_name or "?") .. "\nAvailable: " .. table.concat(themes, ", "),
+			vim.log.levels.INFO
+		)
+		return
+	end
+	if not is_valid(name) then
+		vim.notify("Unknown theme '" .. name .. "'. Available: " .. table.concat(themes, ", "), vim.log.levels.ERROR)
+		return
+	end
+	if write_persisted(name) then
+		vim.notify(
+			"Theme set to '" .. name .. "'. Restart Neovim to apply (it installs on next launch).",
+			vim.log.levels.INFO
+		)
+	else
+		vim.notify("Could not write theme choice to " .. state_file, vim.log.levels.ERROR)
+	end
+end, {
+	nargs = "?",
+	desc = "Show or switch the active colorscheme (restart-based)",
+	complete = function(arglead)
+		local out = {}
+		for _, n in ipairs(M.list()) do
+			if n:find(arglead, 1, true) == 1 then
+				out[#out + 1] = n
+			end
+		end
+		return out
+	end,
+})
 
 return M

--- a/lua/themes/catppuccin.lua
+++ b/lua/themes/catppuccin.lua
@@ -1,0 +1,8 @@
+return {
+	"catppuccin/nvim",
+	name = "catppuccin",
+	config = function()
+		vim.g.catppuccin_flavour = "mocha" -- latte, frappe, macchiato, mocha
+		vim.cmd([[colorscheme catppuccin]])
+	end,
+}

--- a/lua/themes/dracula.lua
+++ b/lua/themes/dracula.lua
@@ -1,0 +1,8 @@
+return {
+	"Mofiqul/dracula.nvim",
+	config = function()
+		local theme = require("dracula")
+		theme.setup({})
+		theme.load()
+	end,
+}

--- a/lua/themes/draculanight.lua
+++ b/lua/themes/draculanight.lua
@@ -1,0 +1,8 @@
+return {
+	"magidc/draculanight",
+	config = function()
+		local theme = require("draculanight")
+		theme.setup({})
+		theme.load()
+	end,
+}

--- a/lua/themes/everforest.lua
+++ b/lua/themes/everforest.lua
@@ -1,0 +1,14 @@
+-- Everforest — warm green-grey, muted, designed for low fatigue.
+return {
+	"sainnhe/everforest",
+	config = function()
+		vim.o.background = "dark"
+		vim.g.everforest_background = "medium" -- hard | medium | soft
+		vim.g.everforest_foreground = "material"
+		vim.g.everforest_ui_contrast = "low"
+		vim.g.everforest_enable_italic = true
+		vim.g.everforest_better_performance = 1
+		vim.g.everforest_transparent_background = 0
+		vim.cmd.colorscheme("everforest")
+	end,
+}

--- a/lua/themes/gruvbox.lua
+++ b/lua/themes/gruvbox.lua
@@ -1,0 +1,17 @@
+-- Gruvbox Material — high-contrast / hard background (original tuning).
+return {
+	"sainnhe/gruvbox-material",
+	config = function()
+		vim.g.gruvbox_material_enable_italic = true
+		vim.cmd.colorscheme("gruvbox-material")
+		vim.g.show_eob = 1
+		vim.g.background = "dark"
+		vim.g.gruvbox_material_background = "hard"
+		vim.g.gruvbox_material_foreground = "material"
+		vim.g.gruvbox_material_cursor = "auto"
+		vim.g.gruvbox_material_show_eob = 0
+		vim.g.gruvbox_material_ui_contrast = "high"
+		vim.g.gruvbox_material_float_style = "bright"
+		vim.g.gruvbox_material_transparent_background = 2
+	end,
+}

--- a/lua/themes/gruvbox_material_soft.lua
+++ b/lua/themes/gruvbox_material_soft.lua
@@ -1,0 +1,15 @@
+-- Gruvbox Material, readability-tuned: medium background + low UI contrast +
+-- no transparency to avoid halation. Low-eyestrain counterpart to "gruvbox".
+return {
+	"sainnhe/gruvbox-material",
+	config = function()
+		vim.o.background = "dark"
+		vim.g.gruvbox_material_background = "medium" -- soft | medium | hard
+		vim.g.gruvbox_material_foreground = "material"
+		vim.g.gruvbox_material_ui_contrast = "low" -- low | high
+		vim.g.gruvbox_material_enable_italic = true
+		vim.g.gruvbox_material_better_performance = 1
+		vim.g.gruvbox_material_transparent_background = 0
+		vim.cmd.colorscheme("gruvbox-material")
+	end,
+}

--- a/lua/themes/kanagawa.lua
+++ b/lua/themes/kanagawa.lua
@@ -1,0 +1,15 @@
+-- Kanagawa — muted "ink painting" palette, warm, low contrast.
+return {
+	"rebelot/kanagawa.nvim",
+	config = function()
+		require("kanagawa").setup({
+			theme = "wave", -- wave (balanced) | dragon (softer, lower contrast)
+			background = { dark = "wave" },
+			transparent = false,
+			dimInactive = false,
+			commentStyle = { italic = true },
+		})
+		vim.o.background = "dark"
+		vim.cmd.colorscheme("kanagawa-wave")
+	end,
+}

--- a/lua/themes/material.lua
+++ b/lua/themes/material.lua
@@ -1,0 +1,6 @@
+return {
+	"marko-cerovac/material.nvim",
+	config = function()
+		require("plugins.configs.materialui")
+	end,
+}

--- a/lua/themes/moonfly.lua
+++ b/lua/themes/moonfly.lua
@@ -1,0 +1,6 @@
+return {
+	"bluz71/vim-moonfly-colors",
+	config = function()
+		vim.cmd([[colorscheme moonfly]])
+	end,
+}

--- a/lua/themes/nordic.lua
+++ b/lua/themes/nordic.lua
@@ -1,0 +1,6 @@
+return {
+	"AlexvZyl/nordic.nvim",
+	config = function()
+		require("nordic").setup({})
+	end,
+}

--- a/lua/themes/onedark.lua
+++ b/lua/themes/onedark.lua
@@ -1,0 +1,21 @@
+return {
+	"navarasu/onedark.nvim",
+	config = function()
+		local theme = require("onedark")
+		theme.setup({
+			style = "deep",
+			transparent = false, -- Show/hide background
+			code_style = {
+				comments = "italic",
+				keywords = "none",
+				functions = "none",
+				strings = "none",
+				variables = "none",
+			},
+			lualine = {
+				transparent = true, -- lualine center bar transparency
+			},
+		})
+		theme.load()
+	end,
+}

--- a/lua/themes/onedarkpro.lua
+++ b/lua/themes/onedarkpro.lua
@@ -1,0 +1,7 @@
+return {
+	"olimorris/onedarkpro.nvim",
+	config = function()
+		vim.o.background = "dark"
+		require("onedarkpro").load()
+	end,
+}

--- a/lua/themes/onenord.lua
+++ b/lua/themes/onenord.lua
@@ -1,0 +1,23 @@
+return {
+	"rmehri01/onenord.nvim",
+	config = function()
+		require("onenord").setup({
+			borders = true,
+			fade_nc = false,
+			styles = {
+				comments = "italic",
+				strings = "NONE",
+				keywords = "NONE",
+				functions = "italic",
+				variables = "bold",
+				diagnostics = "underline",
+			},
+			disable = {
+				background = false,
+				cursorline = false,
+				eob_lines = true,
+			},
+			colors = {},
+		})
+	end,
+}

--- a/lua/themes/palenightfall.lua
+++ b/lua/themes/palenightfall.lua
@@ -1,0 +1,6 @@
+return {
+	"JoosepAlviste/palenightfall.nvim",
+	config = function()
+		require("palenightfall").setup({})
+	end,
+}

--- a/lua/themes/tokyodark.lua
+++ b/lua/themes/tokyodark.lua
@@ -1,0 +1,10 @@
+return {
+	"tiagovla/tokyodark.nvim",
+	config = function()
+		vim.g.tokyodark_transparent_background = false
+		vim.g.tokyodark_enable_italic_comment = true
+		vim.g.tokyodark_enable_italic = true
+		vim.g.tokyodark_color_gamma = "0.0"
+		vim.cmd("colorscheme tokyodark")
+	end,
+}

--- a/lua/themes/tokyonight.lua
+++ b/lua/themes/tokyonight.lua
@@ -1,0 +1,16 @@
+-- Tokyonight — 'night' style with near-black background (original tuning).
+return {
+	"folke/tokyonight.nvim",
+	config = function()
+		local theme = require("tokyonight")
+		theme.setup({
+			style = "night",
+			on_colors = function(colors)
+				colors.bg_dark = "#000000"
+				colors.bg = "#11121D"
+				-- colors.bg_visual = require("theme").colors.grey12
+			end,
+		})
+		theme.load()
+	end,
+}

--- a/lua/themes/tokyonight_moon.lua
+++ b/lua/themes/tokyonight_moon.lua
@@ -1,0 +1,12 @@
+-- Tokyonight 'moon' — softer than 'night', no forced near-black background.
+return {
+	"folke/tokyonight.nvim",
+	config = function()
+		local theme = require("tokyonight")
+		theme.setup({
+			style = "moon",
+			styles = { comments = { italic = true } },
+		})
+		theme.load()
+	end,
+}

--- a/lua/themes/zenbones.lua
+++ b/lua/themes/zenbones.lua
@@ -1,0 +1,12 @@
+-- Zenbones (dark) — built on lush.nvim with deliberately engineered contrast
+-- ratios; warm and muted. Requires the lush.nvim dependency.
+return {
+	"mcchrish/zenbones.nvim",
+	dependencies = { "rktjmp/lush.nvim" },
+	config = function()
+		vim.o.background = "dark"
+		vim.g.zenbones_darkness = "warm" -- "" | warm | stark
+		vim.g.zenbones_lighten_comments = 10
+		vim.cmd.colorscheme("zenbones")
+	end,
+}


### PR DESCRIPTION
## What

Refactors the theme configuration into a plug-n-play, one-file-per-theme system.

- **`lua/themes/<name>.lua`** — each colorscheme is now its own file returning a lazy.nvim spec. The 13 existing themes are migrated verbatim (including `gruvbox` with its original hard/high-contrast tuning).
- **`lua/theme.lua`** — rewritten as an auto-discovering loader. It scans `lua/themes/*.lua`, keeps the existing public API (`colors`, `set_active_theme`, `get_active_theme`, `theme_name`) so `bufferline`, `scrollbar` and `plugins/init.lua` keep working, persists the active choice to a machine-local state file, and adds a `:Theme` command with completion. Only the active theme plugin is ever installed.
- **`lua/plugins/configs/lualine.lua`** — statusline switched to `theme = "auto"` so the bar follows any colorscheme (the previous `theme_name` string errors on themes without a matching lualine theme, e.g. `zenbones`, `tokyonight_moon`).

## New low-eyestrain dark themes

Added five medium-contrast, warm, desaturated themes: `gruvbox_material_soft`, `everforest`, `kanagawa`, `tokyonight_moon`, `zenbones` (requires `lush.nvim`).

## Usage

- Add a theme → drop a file in `lua/themes/`. No central edits.
- Switch → `:Theme <name>` (tab-completes), then restart (lazy installs it on next launch).
- Default still set in `settings.lua` via `set_active_theme(...)`; a `:Theme` choice overrides it.

## Validation

- `luac -p` on all 20 changed files — clean.
- Headless loader tests: 18 themes discovered, resolve + persist + unknown-name guard all pass.
- Full devcontainer CI suite run locally (Neovim v0.12.3): green (exit 0), startup + full plugin load + all 11 treesitter parsers pass.

## Note (out of scope)

Discovered that the CI reports green while swallowing headless Lua errors (`nvim --headless -c qall` exits 0 after an error). Pre-existing, unrelated to this change; left as-is per discussion. Candidate for a follow-up PR (switch to `nvim -l`, add theme launch tests, fix `after/lsp/*.lua` to the 0.12 `return {...}` form).