### PR TITLE
fix(lsp): return config table from after/lsp specs (Neovim 0.12)

### DIFF
--- a/after/lsp/ansiblels.lua
+++ b/after/lsp/ansiblels.lua
@@ -1,4 +1,4 @@
-vim.lsp.config('ansiblels', {
+return {
   settings = {
     ansible = {
       ansible = {
@@ -19,4 +19,4 @@ vim.lsp.config('ansiblels', {
       },
     },
   },
-})
+}

--- a/after/lsp/eslint.lua
+++ b/after/lsp/eslint.lua
@@ -1,11 +1,9 @@
-vim.lsp.config('eslint', {
-  settings = {
-    packageManager = "npm",
-  },
-})
-
--- EslintFixAll on save, scoped to eslint-attached buffers only
+-- EslintFixAll on save, scoped to eslint-attached buffers only.
+-- Registered as a side effect when this config file is sourced; the augroup's
+-- clear = true keeps it idempotent if the file is sourced more than once.
+local group = vim.api.nvim_create_augroup("EslintFixOnSave", { clear = true })
 vim.api.nvim_create_autocmd("LspAttach", {
+  group = group,
   callback = function(args)
     local client = vim.lsp.get_client_by_id(args.data.client_id)
     if client and client.name == "eslint" then
@@ -16,3 +14,9 @@ vim.api.nvim_create_autocmd("LspAttach", {
     end
   end,
 })
+
+return {
+  settings = {
+    packageManager = "npm",
+  },
+}

--- a/after/lsp/gopls.lua
+++ b/after/lsp/gopls.lua
@@ -1,4 +1,5 @@
-vim.lsp.config('gopls', {
+-- Merged into the gopls config resolved by vim.lsp (Neovim 0.11+ native API).
+return {
   settings = {
     gopls = {
       analyses = {
@@ -9,4 +10,4 @@ vim.lsp.config('gopls', {
       gofumpt = true,
     },
   },
-})
+}

--- a/after/lsp/helm_ls.lua
+++ b/after/lsp/helm_ls.lua
@@ -1,4 +1,4 @@
-vim.lsp.config('helm_ls', {
+return {
   settings = {
     ['helm-ls'] = {
       logLevel = "info",
@@ -22,4 +22,4 @@ vim.lsp.config('helm_ls', {
       },
     },
   },
-})
+}

--- a/after/lsp/jsonnet_ls.lua
+++ b/after/lsp/jsonnet_ls.lua
@@ -1,4 +1,4 @@
-vim.lsp.config('jsonnet_ls', {
+return {
   cmd = { "jsonnet-language-server", "-t" },
   settings = {
     ext_vars = {},
@@ -11,4 +11,4 @@ vim.lsp.config('jsonnet_ls', {
       SortImports = true,
     },
   },
-})
+}

--- a/after/lsp/lua_ls.lua
+++ b/after/lsp/lua_ls.lua
@@ -1,4 +1,4 @@
-vim.lsp.config('lua_ls', {
+return {
   settings = {
     Lua = {
       runtime = { version = "LuaJIT" },
@@ -7,4 +7,4 @@ vim.lsp.config('lua_ls', {
       telemetry = { enable = false },
     },
   },
-})
+}

--- a/after/lsp/rust_analyzer.lua
+++ b/after/lsp/rust_analyzer.lua
@@ -1,4 +1,4 @@
-vim.lsp.config('rust_analyzer', {
+return {
   settings = {
     ["rust-analyzer"] = {
       diagnostics = { enable = true },
@@ -10,4 +10,4 @@ vim.lsp.config('rust_analyzer', {
       procMacro = { enable = true },
     },
   },
-})
+}

--- a/after/lsp/yamlls.lua
+++ b/after/lsp/yamlls.lua
@@ -1,4 +1,4 @@
-vim.lsp.config('yamlls', {
+return {
   settings = {
     yaml = {
       validate = true,
@@ -20,4 +20,4 @@ vim.lsp.config('yamlls', {
       },
     },
   },
-})
+}


### PR DESCRIPTION
## Problem

Neovim startup crashes (issue #36):

```
Failed to run `config` for mason-lspconfig.nvim
.../after/lsp/ansiblels.lua: not a table
  vim/lsp.lua:347 __index → vim/lsp.lua:617 enable
  → mason-lspconfig automatic_enable → mason.lua:19
```

On **Neovim 0.12** the `vim.lsp.config[name]` getter re-sources `after/lsp/<name>.lua` and requires it to **return** a table. The specs used the imperative setter form `vim.lsp.config('name', {...})`, which returns `nil` — so when `mason-lspconfig`'s `automatic_enable` calls `vim.lsp.enable(name)` (→ the getter), it throws `not a table` and aborts startup.

## Fix

Convert all eight `after/lsp/*.lua` specs to the declarative `return { ... }` form (the documented Neovim 0.11+ native pattern). `gopls`, `lua_ls`, `rust_analyzer`, `helm_ls`, `yamlls`, `ansiblels`, `jsonnet_ls`, `eslint`.

`eslint` keeps its `EslintFixAll`-on-save autocmd, now registered under a `clear = true` augroup so re-sourcing during config resolution stays idempotent.

## Validation

Ran against **nvim v0.12.2** (the version in the report):
- `luac -p` clean on all 8 files.
- Each file now returns a table with its `settings` (and `jsonnet_ls` its `cmd`).
- `vim.lsp.config[name]` — the exact failing frame — resolves for all 8 servers with settings merged, no throw (previously threw for `ansiblels`).

Fixes #36.