### PR TITLE
chore: add .stow-local-ignore for stow deploys

### DIFF
--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -1,0 +1,11 @@
+\.git
+\.gitignore
+\.gitattributes
+^/README.*
+^/LICENSE.*
+screenshots
+test
+\.devcontainer
+\.github
+install_nvim\.sh
+\.editorconfig


### PR DESCRIPTION
## Summary
- Add `.stow-local-ignore` so GNU Stow deploys of this repo (e.g. into `~/.config/nvim`) skip non-config files: screenshots, tests, devcontainer, GitHub workflows, the install script, and editor/git metadata.
- Stow's default ignore list is replaced (not extended) by a custom `.stow-local-ignore`, so the usual defaults (`.git`, `README.*`, `LICENSE.*`) are re-declared explicitly.

## Test plan
- [x] `stow -d ~/dev/repos/personal/fun -t ~/.config/nvim nvim-config` links only config files on macOS
- [x] `nvim --headless "+Lazy! sync" +qa` exits clean