### PR TITLE
fix(treesitter): use master textobjects module

### DIFF
--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -3,13 +3,13 @@ return {
 	branch = "master",
 	build = ":TSUpdate",
 	dependencies = {
-		"nvim-treesitter/nvim-treesitter-textobjects",
+		{ "nvim-treesitter/nvim-treesitter-textobjects", branch = "master" },
 		"windwp/nvim-ts-autotag",
 		"nvim-treesitter/nvim-treesitter-refactor",
 		"andymass/vim-matchup",
 	},
 	config = function()
-		local ts_repeat_move = require("nvim-treesitter-textobjects.repeatable_move")
+		local ts_repeat_move = require("nvim-treesitter.textobjects.repeatable_move")
 
 		-- vim way: ; goes to the direction you were moving.
 		vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)


### PR DESCRIPTION
## Problem

Neovim startup failed with:

```
Failed to run `config` for nvim-treesitter
module 'nvim-treesitter-textobjects.repeatable_move' not found
```

`treesitter.lua` required `nvim-treesitter-textobjects.repeatable_move` — the module path from the plugin's rewritten **main** branch — while the installed plugin (and the whole config: nvim-treesitter pinned to `master`, textobjects configured via `nvim-treesitter.configs.setup()`) uses the **master**-branch API, where the module lives at `nvim-treesitter.textobjects.repeatable_move`.

## Fix

- Correct the require path to the master-branch module.
- Pin the dependency to `branch = "master"` explicitly: upstream froze master on 2025-10-31 and switched the default branch to `main`, so a fresh clone without the pin would install the incompatible rewrite.

## Verification

`nvim --headless` starts cleanly; `require('nvim-treesitter.textobjects.repeatable_move').repeat_last_move` resolves to a function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)